### PR TITLE
fix DatabaseCache.delete return value

### DIFF
--- a/django/core/cache/backends/db.py
+++ b/django/core/cache/backends/db.py
@@ -225,7 +225,7 @@ class DatabaseCache(BaseDatabaseCache):
                 ),
                 keys,
             )
-        return bool(cursor.rowcount)
+            return bool(cursor.rowcount)
 
     def has_key(self, key, version=None):
         key = self.make_key(key, version=version)


### PR DESCRIPTION
The cursor rowcount value was evaluated after the cursor was closed.